### PR TITLE
Updated to release 2026.07.02

### DIFF
--- a/.abf.yml
+++ b/.abf.yml
@@ -1,3 +1,3 @@
 sources:
-  dosbox-x-v2026.01.02.tar.gz: 0bc697567f086ae8012641dd699477d5e422e8ad
-  dosbox-x-v2026.03.29.tar.gz: 4b8843332198279e81366f04291d5a3aed94619e
+  dosbox-x-dosbox-x-v2026.07.02.tar.gz: a3a53798ad3bd49d02c54eef6f4b5b7c3e4427c8
+

--- a/dosbox-x-2026.07.02-fix-FSF-address.patch
+++ b/dosbox-x-2026.07.02-fix-FSF-address.patch
@@ -1,0 +1,24 @@
+diff -rupN dosbox-x-dosbox-x-v2026.07.02.old/contrib/glshaders/crt-caligari.glsl dosbox-x-dosbox-x-v2026.07.02/contrib/glshaders/crt-caligari.glsl
+--- dosbox-x-dosbox-x-v2026.07.02.old/contrib/glshaders/crt-caligari.glsl	2026-07-03 03:37:43.000000000 +0200
++++ dosbox-x-dosbox-x-v2026.07.02/contrib/glshaders/crt-caligari.glsl	2026-07-05 18:12:13.205089705 +0200
+@@ -17,7 +17,7 @@
+ 
+ 	You should have received a copy of the GNU General Public License along
+ 	with this program; if not, write to the Free Software Foundation, Inc.,
+-	51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
++	31 Milk Street, # 960789, Boston, MA 02196, USA.
+ 
+ */
+ 
+diff -rupN dosbox-x-dosbox-x-v2026.07.02.old/COPYING dosbox-x-dosbox-x-v2026.07.02/COPYING
+--- dosbox-x-dosbox-x-v2026.07.02.old/COPYING	2026-07-03 03:37:43.000000000 +0200
++++ dosbox-x-dosbox-x-v2026.07.02/COPYING	2026-07-05 18:12:29.485327312 +0200
+@@ -2,7 +2,7 @@
+ 		       Version 2, June 1991
+ 
+  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ 31 Milk Street, # 960789, Boston, MA 02196, USA
+  Everyone is permitted to copy and distribute verbatim copies
+  of this license document, but changing it is not allowed.
+ 

--- a/dosbox-x.spec
+++ b/dosbox-x.spec
@@ -3,37 +3,47 @@
 
 Summary: DOS Emulator
 Name: dosbox-x
-Version: 2026.03.29
+Version: 2026.07.02
 License: GPLv2+
 Group: Emulators
 Release: 1
 Url: https://dosbox-x.com
-Source0: https://github.com/joncampbell123/dosbox-x/archive/refs/tags/dosbox-x-v%{version}.tar.gz
+Source0: https://github.com/joncampbell123/dosbox-x/archive/refs/tags/%{name}-%{name}-v%{version}.tar.gz
+Patch0:	dosbox-x-2026.07.02-fix-FSF-address.patch
 BuildRequires: autoconf
 BuildRequires: automake
 BuildRequires: chrpath
+BuildRequires: dos2unix
 BuildRequires: libtool-base
 BuildRequires: m4
 BuildRequires: make
+BuildRequires: nasm
 BuildRequires: slibtool
 BuildRequires: atomic-devel
+BuildRequires: SDL_sound-devel
 BuildRequires: pkgconfig(alsa)
 BuildRequires: pkgconfig(fluidsynth)
+BuildRequires: pkgconfig(freetype2)
 BuildRequires: pkgconfig(gl)
 BuildRequires: pkgconfig(gtest)
 BuildRequires: pkgconfig(gmock)
 BuildRequires: pkgconfig(iir)
+BuildRequires: pkgconfig(libavcodec)
+BuildRequires: pkgconfig(libpcap)
 BuildRequires: pkgconfig(libpng)
 BuildRequires: pkgconfig(mt32emu)
+BuildRequires: pkgconfig(ncurses)
 BuildRequires: pkgconfig(opusfile)
 BuildRequires: pkgconfig(sdl2)
+#BuildRequires: pkgconfig(sdl3)
 BuildRequires: pkgconfig(SDL2_net)
 BuildRequires: pkgconfig(SDL2_image)
 BuildRequires: pkgconfig(slirp) >= 4.6.1
 BuildRequires: pkgconfig(speexdsp)
 BuildRequires: pkgconfig(x11)
 BuildRequires: pkgconfig(xrandr)
-Obsoletes: dosbox < %{EVRD}
+BuildRequires: pkgconfig(zlib)
+%rename dosbox
 
 %description
 This is a DOS emulator, emulating 286/386 CPUs, filesystems, XMS/EMS, various
@@ -55,20 +65,29 @@ the codebase and add new features.
 
 %prep
 %autosetup -p1 -n %{name}-%{name}-v%{version}
+
+# Fix EOL
+dos2unix CHANGELOG
+dos2unix README.video
+dos2unix README.md
+
+
+%build
 # Remove deprecated entries in configure.ac
 autoupdate
 ./autogen.sh || :
 
+# Using SDL3 disables some things  (gamelink support, internal modem and IPX support)
+# and  makes the build fail because of a missing include... stay on SDL2 for now
 %configure \
-	--enable-sdl2
+		--enable-sdl2 \
+		--enable-avcodec
 
-
-%build
 %make_build
 
 
 %install
 %make_install
 
-# Fix chrpath
+# Fix rpath
 chrpath -d %{buildroot}%{_bindir}/%{name}


### PR DESCRIPTION
Updated to release 2026.07.02, added P0 to fix rpmlint errors, updated BReqs.